### PR TITLE
Add JSONL exporter and update scraping outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ This scraper scrapes:
 - Linkedin article pages for article data
 
 For output examples see the `./results` directory.
+Scraped data is also exported in the `data_source` directory using the JSON
+Lines format. Large datasets are automatically split into `chunk_###.jsonl`
+files with up to 100,000 records each.
 
 ## Fair Use Disclaimer
 

--- a/run.py
+++ b/run.py
@@ -5,13 +5,17 @@ It scrapes product data and saves it to ./results/
 To run this script set the env variable $SCRAPFLY_KEY with your scrapfly API key:
 $ export $SCRAPFLY_KEY="your key from https://scrapfly.io/dashboard"
 """
+
 import asyncio
 import json
 from pathlib import Path
 import linkedin
+from utils import save_jsonl
 
 output = Path(__file__).parent / "results"
 output.mkdir(exist_ok=True)
+data_output = Path(__file__).parent / "data_source"
+data_output.mkdir(exist_ok=True)
 
 
 async def run():
@@ -21,55 +25,54 @@ async def run():
 
     print("running Linkedin scrape and saving results to ./results directory")
 
-    profile_data = await linkedin.scrape_profile(
-        urls=[
-            "https://www.linkedin.com/in/williamhgates"
-        ]
-    )
+    profile_data = await linkedin.scrape_profile(urls=["https://www.linkedin.com/in/williamhgates"])
     with open(output.joinpath("profile.json"), "w", encoding="utf-8") as file:
-        json.dump(profile_data, file, indent=2, ensure_ascii=False)    
+        json.dump(profile_data, file, indent=2, ensure_ascii=False)
+    save_jsonl(profile_data, data_output, prefix="profile")
 
     company_data = await linkedin.scrape_company(
         urls=[
             "https://linkedin.com/company/microsoft",
             "https://linkedin.com/company/google",
-            "https://linkedin.com/company/apple"
+            "https://linkedin.com/company/apple",
         ]
     )
     with open(output.joinpath("company.json"), "w", encoding="utf-8") as file:
-        json.dump(company_data, file, indent=2, ensure_ascii=False)    
+        json.dump(company_data, file, indent=2, ensure_ascii=False)
+    save_jsonl(company_data, data_output, prefix="company")
 
     job_search_data = await linkedin.scrape_job_search(
         # it include other search parameters, refer to the search pages on browser for more details
         keyword="Python Developer",
         location="United States",
-        max_pages=3
+        max_pages=3,
     )
     with open(output.joinpath("job_search.json"), "w", encoding="utf-8") as file:
-        json.dump(job_search_data, file, indent=2, ensure_ascii=False)    
+        json.dump(job_search_data, file, indent=2, ensure_ascii=False)
+    save_jsonl(job_search_data, data_output, prefix="job_search")
 
     job_data = await linkedin.scrape_jobs(
         urls=[
             "https://www.linkedin.com/jobs/view/data-center-engineering-operations-engineer-hyd-infinity-dceo-at-amazon-web-services-aws-4017265505",
             "https://www.linkedin.com/jobs/view/content-strategist-google-cloud-content-strategy-and-experience-at-google-4015776107",
-            "https://www.linkedin.com/jobs/view/sr-content-marketing-manager-brand-protection-brand-protection-at-amazon-4007942181"
+            "https://www.linkedin.com/jobs/view/sr-content-marketing-manager-brand-protection-brand-protection-at-amazon-4007942181",
         ]
     )
     with open(output.joinpath("jobs.json"), "w", encoding="utf-8") as file:
         json.dump(job_data, file, indent=2, ensure_ascii=False)
-
+    save_jsonl(job_data, data_output, prefix="jobs")
 
     artcile_data = await linkedin.scrape_articles(
         urls=[
             "https://www.linkedin.com/pulse/last-chapter-my-career-bill-gates-tvlnc",
             "https://www.linkedin.com/pulse/drone-didis-taking-flight-bill-gates-b1okc",
-            "https://www.linkedin.com/pulse/world-has-lot-learn-from-india-bill-gates-vaubc"
+            "https://www.linkedin.com/pulse/world-has-lot-learn-from-india-bill-gates-vaubc",
         ]
     )
     with open(output.joinpath("articles.json"), "w", encoding="utf-8") as file:
-        json.dump(artcile_data, file, indent=2, ensure_ascii=False)    
+        json.dump(artcile_data, file, indent=2, ensure_ascii=False)
+    save_jsonl(artcile_data, data_output, prefix="articles")
 
 
 if __name__ == "__main__":
     asyncio.run(run())
-        

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+
+
+def save_jsonl(records, output_dir, prefix="chunk", chunk_size=100000):
+    """Save list of records to JSONL files.
+
+    Parameters
+    ----------
+    records : list
+        List of dictionaries to save.
+    output_dir : str or Path
+        Directory path where JSONL files will be created.
+    prefix : str, optional
+        File name prefix for chunk files, by default "chunk".
+    chunk_size : int, optional
+        Maximum number of records per chunk file, by default 100000.
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    total = len(records)
+    if total == 0:
+        return
+
+    if total > chunk_size:
+        for index in range(0, total, chunk_size):
+            chunk_records = records[index : index + chunk_size]
+            chunk_path = output_dir / f"{prefix}_{index // chunk_size + 1:03d}.jsonl"
+            with open(chunk_path, "w", encoding="utf-8") as f:
+                for record in chunk_records:
+                    f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    else:
+        chunk_path = output_dir / f"{prefix}_001.jsonl"
+        with open(chunk_path, "w", encoding="utf-8") as f:
+            for record in records:
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")


### PR DESCRIPTION
## Summary
- add `utils.save_jsonl` to write records in JSONL format with automatic chunking
- update `run.py` to output scraped data into a new `data_source` directory using JSONL files
- document the new JSONL exports in `README`
- include a placeholder file for the new data directory

## Testing
- `ruff check run.py utils.py`
- `black run.py utils.py`
- `pytest -k "" -q` *(fails: KeyError: 'SCRAPFLY_KEY')*


------
https://chatgpt.com/codex/tasks/task_e_685a11a76da883238769ef79b1d42933